### PR TITLE
Refactor the input field component

### DIFF
--- a/client/src/components/common/InputField/index.jsx
+++ b/client/src/components/common/InputField/index.jsx
@@ -8,12 +8,13 @@ const propTypes = {
   id: PropTypes.string,
   labelText: PropTypes.string,
   type: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   value: PropTypes.string,
   placeholder: PropTypes.string,
   className: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   onClick: PropTypes.func,
+  labelClass: PropTypes.string,
 };
 
 const Input = props => {
@@ -27,10 +28,11 @@ const Input = props => {
     onClick,
     id,
     labelText,
+    labelClass,
   } = props;
 
   return (
-    <label htmlFor={id}>
+    <label htmlFor={id} className={labelClass}>
       {labelText}
       <input
         id={id}
@@ -57,6 +59,8 @@ Input.defaultProps = {
   onClick: null,
   id: null,
   labelText: null,
+  labelClass: null,
+  name: null,
 };
 
 export default Input;


### PR DESCRIPTION
Refactors the input field component to accommodate checkbox and submit button instances. 
in these cases, having the name property required will add additional noise to the state function, and will change the value of the submit button unless manually written in the setstate function. 
Relates #83

